### PR TITLE
set up error middleware

### DIFF
--- a/lib/error-middleware.js
+++ b/lib/error-middleware.js
@@ -1,15 +1,34 @@
 'use strict';
 
-//TODO: ADD error middleware
 const createError = require('http-errors');
 const debug = require('debug')('movies:error-middleware');
 
 module.exports = function(err, req, res, next) {
   debug('error-middleware');
 
+  console.error('error', err);
+
   if(err.status) {
     debug('user error');
 
+    res.status(err.status).send(err.name);
+    next();
+    return;
+  }
+
+  if(err.name === 'ValidationError') {
+    debug('Validation Error');
+
+    err = createError(400, err.message);
+    res.status(err.status).send(err.name);
+    next();
+    return;
+  }
+
+  if(err.name === 'CastError') {
+    debug('Cast Error');
+
+    err = createError(404, err.message);
     res.status(err.status).send(err.name);
     next();
     return;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "DEBUG='movies*' mocha",
-    "start": "DEBUG='movies*' node server.js"
+    "start": "DEBUG='movies*' nodemon server.js"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
     "gulp": "^3.9.1",
     "gulp-eslint": "^3.0.1",
     "gulp-mocha": "^3.0.1",
+    "gulp-nodemon": "^2.2.1",
     "mocha": "^3.2.0",
     "superagent": "^3.3.1"
   },
@@ -35,6 +36,7 @@
     "cors": "^2.8.1",
     "debug": "^2.5.1",
     "express": "^4.14.0",
+    "http-errors": "^1.5.1",
     "mongoose": "^4.7.4",
     "morgan": "^1.7.0"
   }

--- a/test/movies-routes-test.js
+++ b/test/movies-routes-test.js
@@ -52,7 +52,7 @@ describe('Movie Routes', function() {
         request.post(`${url}/api/movies`)
           .send({rating: 5})
           .end( res => {
-            expect(res.status).to.equal(500);
+            expect(res.status).to.equal(400);
             done();
           });
       });
@@ -60,7 +60,7 @@ describe('Movie Routes', function() {
         request.post(`${url}/api/movies`)
           .send({name: 'Should fail'})
           .end( res => {
-            expect(res.status).to.equal(500);
+            expect(res.status).to.equal(400);
             done();
           });
       });
@@ -68,7 +68,7 @@ describe('Movie Routes', function() {
         request.post(`${url}/api/movies`)
           .send({name: 5, rating:'ten'})
           .end( res => {
-            expect(res.status).to.equal(500);
+            expect(res.status).to.equal(400);
             done();
           });
       });


### PR DESCRIPTION
error middleware now handles validation and cast errors with appropriate status codes of 400 and 404 respectively.